### PR TITLE
add some most common apm and npm targets

### DIFF
--- a/lib/npm-apm.js
+++ b/lib/npm-apm.js
@@ -45,6 +45,52 @@ function provideBuilder() {
           sh: false
         });
       }
+
+      function makeConfig(tool) {
+        var _args = [];
+        for (var i = 1; i<arguments.length; i++) {
+          _args.push(arguments[i]);
+        }
+
+        return {
+          name: tool + ': ' + _args.join(' '),
+          exec: tool,
+          args: _args,
+          sh: false
+        };
+      }
+
+      if (!pkg.engines.node) {
+        config.push(
+          makeConfig('apm', 'link'),
+          makeConfig('apm', 'link', '--dev'),
+          makeConfig('apm', 'publish', 'patch'),
+          makeConfig('apm', 'publish', 'minor'),
+          makeConfig('apm', 'publish', 'major'),
+          makeConfig('apm', 'unlink'),
+          makeConfig('apm', 'unlink', '--dev'),
+          makeConfig('apm', 'upgrade', '--no-confirm'),
+          makeConfig('apm', 'upgrade', '--list')
+        );
+      }
+
+      config.push(
+        makeConfig('npm', 'install'),
+        makeConfig('npm', 'update')
+        );
+
+      if (pkg.engines.node) {
+        config.push(
+          makeConfig('npm', 'link'),
+          makeConfig('npm', 'publish'),
+          makeConfig('npm', 'unlink'),
+          makeConfig('npm', 'version', 'patch'),
+          makeConfig('npm', 'version', 'minor'),
+          makeConfig('npm', 'version', 'major')
+        );
+
+      }
+
       return config;
     }
   };


### PR DESCRIPTION
run e.g. apm publish patch for publishing your package right from atom
