### PR TITLE
Use service api v2 of atom-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ notifications:
     on_failure: always
     on_start: false
 
-env:
-  - APM_TEST_PACKAGES=build
-
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
 
 git:

--- a/lib/npm-apm.js
+++ b/lib/npm-apm.js
@@ -3,16 +3,21 @@
 import fs from 'fs';
 import path from 'path';
 
-function provideBuilder() {
-  return {
-    niceName: 'npm or apm',
+export function provideBuilder() {
+  return class NpmApmBuildProvider {
+    constructor(cwd) {
+      this.cwd = cwd;
+    }
+    getNiceName() {
+      return 'npm or apm';
+    }
 
-    isEligable: function (cwd) {
-      if (!fs.existsSync(path.join(cwd, 'package.json'))) {
+    isEligible() {
+      if (!fs.existsSync(path.join(this.cwd, 'package.json'))) {
         return false;
       }
 
-      const realPackage = fs.realpathSync(path.join(cwd, 'package.json'));
+      const realPackage = fs.realpathSync(path.join(this.cwd, 'package.json'));
       delete require.cache[realPackage];
       const pkg = require(realPackage);
 
@@ -21,10 +26,10 @@ function provideBuilder() {
       }
 
       return true;
-    },
+    }
 
-    settings: function (cwd) {
-      const realPackage = fs.realpathSync(path.join(cwd, 'package.json'));
+    settings() {
+      const realPackage = fs.realpathSync(path.join(this.cwd, 'package.json'));
       delete require.cache[realPackage];
       const pkg = require(realPackage);
 
@@ -50,5 +55,3 @@ function provideBuilder() {
     }
   };
 }
-
-module.exports.provideBuilder = provideBuilder;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "builder": {
       "description": "Runs npm/apm targets",
       "versions": {
-        "1.0.0": "provideBuilder"
+        "2.0.0": "provideBuilder"
       }
     }
   },


### PR DESCRIPTION
Also move specs away from depending on atom-build,
rather test that it provides correctly, and let tests on
atom-build make sure it consumes correctly.
