### PR TITLE
Custom scripts need .cmd extension on windows

### DIFF
--- a/lib/npm-apm.js
+++ b/lib/npm-apm.js
@@ -45,7 +45,7 @@ export function provideBuilder() {
         if (pkg.scripts.hasOwnProperty(script)) {
           config.push({
             name: 'npm: ' + script,
-            exec: 'npm',
+            exec: 'npm' + executableExtension,
             args: [ '--color=always', 'run', script ],
             sh: false
           });


### PR DESCRIPTION
This was already done for the default target.

Fixes #1
