### PR TITLE
enforce color use in tools

### DIFF
--- a/lib/npm-apm.js
+++ b/lib/npm-apm.js
@@ -35,7 +35,7 @@ export function provideBuilder() {
 
       const executableExtension = /^win/.test(process.platform) ? '.cmd' : '';
       // https://github.com/mochajs/mocha/issues/1844
-      const env = {FORCE_COLOR: '1', MOCHA_COLORS: '1'}
+      const env = {FORCE_COLOR: '1', MOCHA_COLORS: '1'};
       const config = [ {
         name: pkg.engines.node ? 'npm: default' : 'apm: default',
         exec: (pkg.engines.node ? 'npm' : 'apm') + executableExtension,

--- a/lib/npm-apm.js
+++ b/lib/npm-apm.js
@@ -34,10 +34,13 @@ export function provideBuilder() {
       const pkg = require(realPackage);
 
       const executableExtension = /^win/.test(process.platform) ? '.cmd' : '';
+      // https://github.com/mochajs/mocha/issues/1844
+      const env = {FORCE_COLOR: '1', MOCHA_COLORS: '1'}
       const config = [ {
         name: pkg.engines.node ? 'npm: default' : 'apm: default',
         exec: (pkg.engines.node ? 'npm' : 'apm') + executableExtension,
-        args: [ '--color=always', 'install' ],
+        args: [ 'install' ],
+        env: env,
         sh: false
       } ];
 
@@ -46,7 +49,8 @@ export function provideBuilder() {
           config.push({
             name: 'npm: ' + script,
             exec: 'npm' + executableExtension,
-            args: [ '--color=always', 'run', script ],
+            args: [ 'run', script ],
+            env: env,
             sh: false
           });
         }

--- a/spec/build-npm-apm-spec.js
+++ b/spec/build-npm-apm-spec.js
@@ -39,12 +39,12 @@ describe('npm apm provider', () => {
           const defaultTarget = settings.find(s => s.name === 'npm: default');
           expect(defaultTarget.exec).toBe('npm');
           expect(defaultTarget.sh).toBe(false);
-          expect(defaultTarget.args).toEqual([ '--color=always', 'install' ]);
+          expect(defaultTarget.args).toEqual([ 'install' ]);
 
           const customTarget = settings.find(s => s.name === 'npm: custom script');
           expect(customTarget.exec).toBe('npm');
           expect(customTarget.sh).toBe(false);
-          expect(customTarget.args).toEqual([ '--color=always', 'run', 'custom script' ]);
+          expect(customTarget.args).toEqual([ 'run', 'custom script' ]);
         });
       });
     });
@@ -66,12 +66,12 @@ describe('npm apm provider', () => {
           const defaultTarget = settings.find(s => s.name === 'apm: default');
           expect(defaultTarget.exec).toBe('apm');
           expect(defaultTarget.sh).toBe(false);
-          expect(defaultTarget.args).toEqual([ '--color=always', 'install' ]);
+          expect(defaultTarget.args).toEqual([ 'install' ]);
 
           const customTarget = settings.find(s => s.name === 'npm: custom script');
           expect(customTarget.exec).toBe('npm');
           expect(customTarget.sh).toBe(false);
-          expect(customTarget.args).toEqual([ '--color=always', 'run', 'custom script' ]);
+          expect(customTarget.args).toEqual([ 'run', 'custom script' ]);
         });
       });
     });


### PR DESCRIPTION
…as --color doesn’t propagate to scripts.

mocha needs an extra treatment due to ancient deps
