### PR TITLE
Default to npm if no `engines` exists

### DIFF
--- a/lib/npm-apm.js
+++ b/lib/npm-apm.js
@@ -13,19 +13,7 @@ export function provideBuilder() {
     }
 
     isEligible() {
-      if (!fs.existsSync(path.join(this.cwd, 'package.json'))) {
-        return false;
-      }
-
-      const realPackage = fs.realpathSync(path.join(this.cwd, 'package.json'));
-      delete require.cache[realPackage];
-      const pkg = require(realPackage);
-
-      if (!pkg.engines || (!pkg.engines.atom && !pkg.engines.node)) {
-        return false;
-      }
-
-      return true;
+      return fs.existsSync(path.join(this.cwd, 'package.json'));
     }
 
     settings() {
@@ -37,8 +25,8 @@ export function provideBuilder() {
       // https://github.com/mochajs/mocha/issues/1844
       const env = {FORCE_COLOR: '1', MOCHA_COLORS: '1'};
       const config = [ {
-        name: pkg.engines.node ? 'npm: default' : 'apm: default',
-        exec: (pkg.engines.node ? 'npm' : 'apm') + executableExtension,
+        name: pkg.engines && pkg.engines.atom ? 'apm: install' : 'npm: install',
+        exec: (pkg.engines && pkg.engines.atom ? 'apm' : 'npm') + executableExtension,
         args: [ 'install' ],
         env: env,
         sh: false

--- a/spec/build-npm-apm-spec.js
+++ b/spec/build-npm-apm-spec.js
@@ -36,7 +36,7 @@ describe('npm apm provider', () => {
         return Promise.resolve(builder.settings()).then(settings => {
           expect(settings.length).toBe(2);
 
-          const defaultTarget = settings.find(s => s.name === 'npm: default');
+          const defaultTarget = settings.find(s => s.name === 'npm: install');
           expect(defaultTarget.exec).toBe('npm');
           expect(defaultTarget.sh).toBe(false);
           expect(defaultTarget.args).toEqual([ 'install' ]);
@@ -63,7 +63,7 @@ describe('npm apm provider', () => {
         return Promise.resolve(builder.settings()).then(settings => {
           expect(settings.length).toBe(2);
 
-          const defaultTarget = settings.find(s => s.name === 'apm: default');
+          const defaultTarget = settings.find(s => s.name === 'apm: install');
           expect(defaultTarget.exec).toBe('apm');
           expect(defaultTarget.sh).toBe(false);
           expect(defaultTarget.args).toEqual([ 'install' ]);
@@ -78,9 +78,24 @@ describe('npm apm provider', () => {
   });
 
   describe('when package.json exists, but no engines', () => {
-    it('should not be eligible', () => {
+    it('should be eligible', () => {
       fs.writeFileSync(`${directory}/package.json`, fs.readFileSync(`${__dirname}/package.json.noengine`));
-      expect(builder.isEligible()).toBe(false);
+      expect(builder.isEligible()).toBe(true);
+    });
+
+    it('should use it with npm', () => {
+      fs.writeFileSync(`${directory}/package.json`, fs.readFileSync(`${__dirname}/package.json.noengine`));
+      expect(builder.isEligible()).toBe(true);
+      waitsForPromise(() => {
+        return Promise.resolve(builder.settings()).then(settings => {
+          expect(settings.length).toBe(1);
+
+          const defaultTarget = settings.find(s => s.name === 'npm: install');
+          expect(defaultTarget.exec).toBe('npm');
+          expect(defaultTarget.sh).toBe(false);
+          expect(defaultTarget.args).toEqual([ 'install' ]);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Also changes the default target to be named 'install'
as this is what it really does.

Fixes #8
