### PR TITLE
move `npm/apm install` to last target

### DIFF
--- a/lib/npm-apm.js
+++ b/lib/npm-apm.js
@@ -24,13 +24,7 @@ export function provideBuilder() {
       const executableExtension = /^win/.test(process.platform) ? '.cmd' : '';
       // https://github.com/mochajs/mocha/issues/1844
       const env = {FORCE_COLOR: '1', MOCHA_COLORS: '1'};
-      const config = [ {
-        name: pkg.engines && pkg.engines.atom ? 'apm: install' : 'npm: install',
-        exec: (pkg.engines && pkg.engines.atom ? 'apm' : 'npm') + executableExtension,
-        args: [ 'install' ],
-        env: env,
-        sh: false
-      } ];
+      const config = [];
 
       for (const script in pkg.scripts) {
         if (pkg.scripts.hasOwnProperty(script)) {
@@ -43,6 +37,13 @@ export function provideBuilder() {
           });
         }
       }
+      config.push({
+        name: pkg.engines && pkg.engines.atom ? 'apm: install' : 'npm: install',
+        exec: (pkg.engines && pkg.engines.atom ? 'apm' : 'npm') + executableExtension,
+        args: [ 'install' ],
+        env: env,
+        sh: false
+      });
       return config;
     }
   };


### PR DESCRIPTION
Reason: First target in the config list becomes the implicit default
build target when a project is opened. The user should be able to chose
this by moving a script to the top of there package.json script list.
