### PR TITLE
Remove platform specific code because atom-build uses cross-spawn-async

### DIFF
--- a/lib/npm-apm.js
+++ b/lib/npm-apm.js
@@ -21,7 +21,6 @@ export function provideBuilder() {
       delete require.cache[realPackage];
       const pkg = require(realPackage);
 
-      const executableExtension = /^win/.test(process.platform) ? '.cmd' : '';
       // https://github.com/mochajs/mocha/issues/1844
       const env = {FORCE_COLOR: '1', MOCHA_COLORS: '1', NPM_CONFIG_COLOR: 'always'};
       const errorMatch = [
@@ -30,7 +29,7 @@ export function provideBuilder() {
       ];
       const config = [ {
         name: pkg.engines && pkg.engines.atom ? 'apm: install' : 'npm: install',
-        exec: (pkg.engines && pkg.engines.atom ? 'apm' : 'npm') + executableExtension,
+        exec: (pkg.engines && pkg.engines.atom ? 'apm' : 'npm'),
         args: [ 'install' ],
         env: env,
         errorMatch: errorMatch,
@@ -41,7 +40,7 @@ export function provideBuilder() {
         if (pkg.scripts.hasOwnProperty(script)) {
           config.push({
             name: 'npm: ' + script,
-            exec: 'npm' + executableExtension,
+            exec: 'npm',
             args: [ 'run', script ],
             env: env,
             errorMatch: errorMatch,


### PR DESCRIPTION
This is a PR to fix #17

Removing the Windows specific code fixes this build runner on my Windows machine.

`cross-spawn-async` was added to `atom-build` [February 2016](https://github.com/noseglid/atom-build/blame/master/package.json#L13). Doesn't seem like there needs to be a fix in this package anymore to work around Windows.
